### PR TITLE
Enable tanh activation for Gaussian densities

### DIFF
--- a/configs/base_gs.yaml
+++ b/configs/base_gs.yaml
@@ -51,7 +51,7 @@ export_usdz:
   apply_normalizing_transform: true
 
 model:
-  density_activation: sigmoid
+  density_activation: tanh
   scale_activation: exp
   default_density: 0.1
   default_scale_factor: 1.0

--- a/threedgrut/export/nurec_templates.py
+++ b/threedgrut/export/nurec_templates.py
@@ -113,7 +113,7 @@ def fill_3dgut_template(
     features_albedo: np.ndarray,
     features_specular: np.ndarray,
     n_active_features: int,
-    density_activation: str = "sigmoid",
+    density_activation: str = "tanh",
     scale_activation: str = "exp",
     rotation_activation: str = "normalize",
     density_kernel_degree: int = 2,

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -580,7 +580,9 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
         return mask
 
     def clamp_density(self):
-        updated_densities = torch.clamp(self.get_density(), min=1e-4, max=1.0 - 1e-4)
+        updated_densities = torch.clamp(
+            self.get_density(), min=-1.0 + 1e-4, max=1.0 - 1e-4
+        )
         optimizable_tensors = self.replace_tensor_to_optimizer(updated_densities, "density")
         self.density = optimizable_tensors["density"]
 

--- a/threedgrut/strategy/mcmc.py
+++ b/threedgrut/strategy/mcmc.py
@@ -90,7 +90,7 @@ class MCMCStrategy(BaseStrategy):
 
     @torch.no_grad()
     def relocate_gaussians(self) -> None:
-        # Get the per Gaussian densities and scales (after sigmoid)
+        # Get the per-Gaussian densities and scales after applying the activation
         densities = self.model.get_density()
         # Find the dead indices
         dead_idxs = torch.where(densities <= self.conf.strategy.opacity_threshold)[0]
@@ -190,7 +190,11 @@ class MCMCStrategy(BaseStrategy):
         )
 
         new_densities = self.model.density_activation_inv(
-            torch.clamp(new_densities, max=1.0 - torch.finfo(torch.float32).eps, min=self.conf.strategy.opacity_threshold)
+            torch.clamp(
+                new_densities,
+                max=1.0 - torch.finfo(torch.float32).eps,
+                min=-1.0 + torch.finfo(torch.float32).eps,
+            )
         )
 
         new_scales = self.model.scale_activation_inv(new_scales)

--- a/threedgrut/utils/gui.py
+++ b/threedgrut/utils/gui.py
@@ -236,7 +236,7 @@ class GUI:
                     show_fullscreen=True,
                     show_in_imgui_window=False,
                     cmap="blues",
-                    vminmax=(0, 1),
+                    vminmax=(-1, 1),
                 )
 
                 self.viz_render_color_buffer = None
@@ -274,7 +274,7 @@ class GUI:
                     show_fullscreen=True,
                     show_in_imgui_window=False,
                     cmap="jet",
-                    vminmax=(0, 1),
+                    vminmax=(-1, 1),
                 )
 
                 self.viz_render_color_buffer = None

--- a/threedgrut/utils/misc.py
+++ b/threedgrut/utils/misc.py
@@ -45,8 +45,14 @@ def inverse_sigmoid(x):
     return torch.log(x / (1 - x))
 
 
+def inverse_tanh(x: torch.Tensor) -> torch.Tensor:
+    """Inverse hyperbolic tangent."""
+    return 0.5 * torch.log((1 + x) / (1 - x))
+
+
 ACTIVATION_DICT: dict[str, Callable[..., torch.Tensor]] = {
     "sigmoid": torch.sigmoid,
+    "tanh": torch.tanh,
     "exp": torch.exp,
     "normalize": torch.nn.functional.normalize,
     "none": lambda x: x,
@@ -54,6 +60,7 @@ ACTIVATION_DICT: dict[str, Callable[..., torch.Tensor]] = {
 
 INVERSE_ACTIVATION_DICT: dict[str, Callable[..., torch.Tensor]] = {
     "sigmoid": inverse_sigmoid,
+    "tanh": inverse_tanh,
     "exp": torch.log,
     "none": lambda x: x,
 }


### PR DESCRIPTION
## Summary
- add tanh activation support and inverse in misc util
- clamp densities in `model` and `mcmc` for range [-1, 1]
- default configs and templates use tanh activation
- adjust GUI density range and clean up comment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b7e5ec254832ebd455cef8df27a91