### PR TITLE
Adjust hyperparameters and add selective SGHMC

### DIFF
--- a/configs/base_gs.yaml
+++ b/configs/base_gs.yaml
@@ -11,7 +11,7 @@ out_dir: "./runs"
 n_iterations: 30000
 with_gui: false
 gui_update_from_device: true
-val_frequency: 5000
+val_frequency: 2000
 num_workers: 24
 use_wandb: false
 wandb_project: "3dgrt"
@@ -87,23 +87,23 @@ optimizer:
 
   lr: 0.0
   eps: 1.e-15
-  momentum: 0.9
+  momentum: 0.7
   damping: 1.e-5
   fisher_alpha: 0.95
 
   params:
     positions:
-      lr: 0.00016 # 3DGS value: 0.00016 initial and decayed to 0.0000016
+      lr: 0.00008 # Reduced learning rate
     density:
-      lr: 0.05 # 3DGS value: 0.05
+      lr: 0.025 # Reduced learning rate
     features_albedo:
-      lr: 0.0025 # 3DGS value: 0.0025
+      lr: 0.00125 # Reduced learning rate
     features_specular:
       lr: ${div:${optimizer.params.features_albedo.lr},20} # 3DGS value 20x smaller than lr of features_albedo
     rotation:
-      lr: 0.001 # 3DGS value: 0.001
+      lr: 0.0005 # Reduced learning rate
     scale:
-      lr: 0.005 # 3DGS value: 0.005
+      lr: 0.0025 # Reduced learning rate
 
 scheduler:
   positions:

--- a/configs/strategy/gs.yaml
+++ b/configs/strategy/gs.yaml
@@ -4,8 +4,8 @@ print_stats: true
 
 densify:
   params: positions # one of [positions, positions_gradient_norm, features_albedo]
-  frequency: 300 # densification_interval in 3DGS with default value 100
-  start_iteration: 500 # densify_from_iter in 3DGS default value 500
+  frequency: 200 # shortened densification interval
+  start_iteration: 100 # earlier densification start
   end_iteration: 15000 # densify_until_iter in 3DGS default value 15_000
   clone_grad_threshold: 0.0002 # Called densify_grad_threshold in 3DGS with default value 0.0002
   split_grad_threshold: 0.0002 # Called densify_grad_threshold in 3DGS with default value 0.0002
@@ -16,9 +16,9 @@ densify:
 # They use the same values for pruning and densification so check the above values
 prune:
   frequency: 100
-  start_iteration: 500
+  start_iteration: 100
   end_iteration: 15000
-  density_threshold: 0.005 # All Gaussians with the absolute density lower than this will be pruned away
+  density_threshold: 0.01 # All Gaussians with the absolute density lower than this will be pruned away
 
 
 # Start and end iteration are not used in 3DGS
@@ -43,6 +43,6 @@ prune_weight:
 
 prune_scale:
   frequency: 100
-  start_iteration: -1
+  start_iteration: 100
   end_iteration: -1
-  threshold: 1.0
+  threshold: 0.5

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -44,7 +44,7 @@ from threedgrut.utils.gui import GUI
 from threedgrut.utils.logger import logger
 from threedgrut.utils.timer import CudaTimer
 from threedgrut.utils.misc import jet_map, create_summary_writer, check_step_condition
-from threedgrut.optimizers import SelectiveAdam
+from threedgrut.optimizers import SelectiveAdam, SGHMC
 
 class Trainer3DGRUT:
     """Trainer for paper: "3D Gaussian Ray Tracing: Fast Tracing of Particle Scenes" """
@@ -742,6 +742,10 @@ class Trainer3DGRUT:
                 if isinstance(model.optimizer, SelectiveAdam):
                     assert outputs['mog_visibility'].shape == model.density.shape, f"Visibility shape {outputs['mog_visibility'].shape} does not match density shape {model.density.shape}"
                     model.optimizer.step(outputs['mog_visibility'])
+                elif isinstance(model.optimizer, SGHMC):
+                    assert outputs['mog_visibility'].shape == model.density.shape, f"Visibility shape {outputs['mog_visibility'].shape} does not match density shape {model.density.shape}"
+                    cooling = max(0.0, 1.0 - global_step / conf.n_iterations)
+                    model.optimizer.step(outputs['mog_visibility'], cooling)
                 else:
                     model.optimizer.step()
                 model.optimizer.zero_grad()


### PR DESCRIPTION
## Summary
- reduce validation frequency and global learning rates
- update GS strategy for earlier densification and pruning
- add selective updates to SGHMC optimizer and apply cooling
- call SGHMC selective step from trainer

## Testing
- `python -m py_compile threedgrut/optimizers/__init__.py threedgrut/trainer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a181fc360832e9cff025f5b5fbcb4