### PR TITLE
Enable multi-GPU training

### DIFF
--- a/configs/base_gs.yaml
+++ b/configs/base_gs.yaml
@@ -13,6 +13,7 @@ with_gui: false
 gui_update_from_device: true
 val_frequency: 2000
 num_workers: 24
+world_size: 1
 use_wandb: false
 wandb_project: "3dgrt"
 test_last: true

--- a/threedgrut/datasets/__init__.py
+++ b/threedgrut/datasets/__init__.py
@@ -18,23 +18,26 @@ from .dataset_colmap import ColmapDataset
 from .dataset_scannetpp import ScannetppDataset
 
 
-def make(name: str, config, ray_jitter):
+def make(name: str, config, ray_jitter, device="cuda"):
     match name:
         case "nerf":
             train_dataset = NeRFDataset(
                 config.path,
+                device=device,
                 split="train",
                 bg_color=config.model.background.color,
                 ray_jitter=ray_jitter,
             )
             val_dataset = NeRFDataset(
                 config.path,
+                device=device,
                 split="val",
                 bg_color=config.model.background.color,
             )
         case "colmap":
             train_dataset = ColmapDataset(
                 config.path,
+                device=device,
                 split="train",
                 downsample_factor=config.dataset.downsample_factor,
                 test_split_interval=config.dataset.test_split_interval,
@@ -42,6 +45,7 @@ def make(name: str, config, ray_jitter):
             )
             val_dataset = ColmapDataset(
                 config.path,
+                device=device,
                 split="val",
                 downsample_factor=config.dataset.downsample_factor,
                 test_split_interval=config.dataset.test_split_interval,
@@ -49,6 +53,7 @@ def make(name: str, config, ray_jitter):
         case "scannetpp":
             train_dataset = ScannetppDataset(
                 config.path,
+                device=device,
                 split="train",
                 ray_jitter=ray_jitter,
                 downsample_factor=config.dataset.downsample_factor,
@@ -56,6 +61,7 @@ def make(name: str, config, ray_jitter):
             )
             val_dataset = ScannetppDataset(
                 config.path,
+                device=device,
                 split="val",
                 downsample_factor=config.dataset.downsample_factor,
                 test_split_interval=config.dataset.test_split_interval,
@@ -68,17 +74,19 @@ def make(name: str, config, ray_jitter):
     return train_dataset, val_dataset
 
 
-def make_test(name: str, config):
+def make_test(name: str, config, device="cuda"):
     match name:
         case "nerf":
             dataset = NeRFDataset(
                 config.path,
+                device=device,
                 split="test",
                 bg_color=config.model.background.color,
             )
         case "colmap":
             dataset = ColmapDataset(
                 config.path,
+                device=device,
                 split="val",
                 downsample_factor=config.dataset.downsample_factor,
                 test_split_interval=config.dataset.test_split_interval,
@@ -86,6 +94,7 @@ def make_test(name: str, config):
         case "scannetpp":
             dataset = ScannetppDataset(
                 config.path,
+                device=device,
                 split="val",
                 downsample_factor=config.dataset.downsample_factor,
                 test_split_interval=config.dataset.test_split_interval,

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -143,7 +143,7 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
 
         return model_params
 
-    def __init__(self, conf, scene_extent=None):
+    def __init__(self, conf, scene_extent=None, device="cuda"):
         super().__init__()
 
         sh_degree = conf.model.progressive_training.max_n_features
@@ -172,7 +172,7 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
         self.ut_kappa = getattr(self.conf.model, "ut_kappa", 0.0)
         self.positions_gradient_norm = None
 
-        self.device = "cuda"
+        self.device = device
         self.optimizer = None
         self.density_activation = get_activation_function(self.conf.model.density_activation)
         self.density_activation_inv = get_activation_function(self.conf.model.density_activation, inverse=True)
@@ -199,6 +199,8 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
             self.renderer = threedgut_tracer.Tracer(conf)
         else:
             raise ValueError(f"Unknown rendering method: {conf.render.method}")
+
+        self.to(self.device)
 
     @torch.no_grad()
     def build_acc(self, rebuild=True):

--- a/threedgrut/utils/dist.py
+++ b/threedgrut/utils/dist.py
@@ -1,0 +1,13 @@
+import torch.distributed as dist
+
+
+def is_dist_avail_and_initialized() -> bool:
+    return dist.is_available() and dist.is_initialized()
+
+
+def get_rank() -> int:
+    return dist.get_rank() if is_dist_avail_and_initialized() else 0
+
+
+def is_main_process() -> bool:
+    return get_rank() == 0

--- a/threedgrut/utils/logger.py
+++ b/threedgrut/utils/logger.py
@@ -16,6 +16,8 @@
 import warnings
 from typing import Optional
 
+from .dist import is_main_process
+
 from rich.console import Console
 from rich.progress import BarColumn, Progress, ProgressColumn, TaskProgressColumn, TextColumn, TimeElapsedColumn
 from rich.text import Text
@@ -57,18 +59,28 @@ class RichLogger:
     finished_tasks = dict()
 
     def info(self, msg):
+        if not is_main_process():
+            return
         self.console.log(f"[INFO] {msg}", style="white")
 
     def warning(self, msg):
+        if not is_main_process():
+            return
         self.console.log(f"[WARNING] {msg}", style="bright_yellow")
 
     def error(self, msg):
+        if not is_main_process():
+            return
         self.console.log(f"[ERROR] {msg}", style="bright_red")
 
     def log_rule(self, text):
+        if not is_main_process():
+            return
         self.console.rule(text)
 
     def log_table(self, title: str, record: dict):
+        if not is_main_process():
+            return
         table = Table(title=title)
         for key in record.keys():
             table.add_column(key, justify="left", style="yellow3", no_wrap=True)
@@ -90,6 +102,8 @@ class RichLogger:
         return " ".join(additional_info)
 
     def start_progress(self, task_name, total_steps, color=None, **metrics):
+        if not is_main_process():
+            return
         additional_info = self._concat_additional_progress_info(**metrics)
         task_id = self.progress.add_task(f"[{color}]{task_name}", total=total_steps, additional_info=additional_info)
         # start progress if it's the first task
@@ -99,12 +113,16 @@ class RichLogger:
         self.progress_tasks[task_name] = dict(task_id=task_id, additional_info="")
 
     def log_progress(self, task_name, advance, **metrics):
+        if not is_main_process():
+            return
         additional_info = self._concat_additional_progress_info(**metrics)
         self.progress.update(
             self.progress_tasks[task_name]["task_id"], advance=advance, additional_info=additional_info
         )
 
     def end_progress(self, task_name):
+        if not is_main_process():
+            return
         task_id = self.progress_tasks[task_name]["task_id"]
         # log task time
         self.finished_tasks[task_name] = dict(name=task_name, elapsed=self.get_task(task_id).elapsed)
@@ -126,6 +144,9 @@ class RichLogger:
         color: str = None,
         transient: bool = False,
     ):
+        if not is_main_process():
+            yield from sequence
+            return
         if color is not None:
             desc_column = TextColumn(f"[{color}][progress.description]" + "{task.description}[default]")
         else:


### PR DESCRIPTION
## Summary
- add distributed utilities
- gate logger output to rank 0
- add `world_size` option and distributed setup in training script
- update datasets and model to respect device
- wrap model with DDP and use distributed samplers

## Testing
- `python -m py_compile train.py threedgrut/utils/dist.py threedgrut/utils/logger.py threedgrut/trainer.py threedgrut/datasets/__init__.py threedgrut/model/model.py`

------
https://chatgpt.com/codex/tasks/task_e_687b2e093ff4832e8c5f3dca00112362