### PR TITLE
Fix pruning and distributed training bugs

### DIFF
--- a/train.py
+++ b/train.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 import hydra
 import torch
@@ -55,6 +56,8 @@ def main(conf: DictConfig) -> None:
     if world_size > torch.cuda.device_count():
         world_size = torch.cuda.device_count()
     if world_size > 1:
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29500")
         mp.spawn(_run, args=(world_size, conf), nprocs=world_size)
     else:
         _run(0, 1, conf)


### PR DESCRIPTION
## Summary
- handle different dataset intrinsic structures in pruning
- initialize distributed training master addr/port if absent

## Testing
- `python -m py_compile threedgrut/strategy/gs.py train.py`


------
https://chatgpt.com/codex/tasks/task_e_687b42ae63e0832eb75228902aa35988