### PR TITLE
Add Ray Tune hyperparameter search script

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ To enable the Unscented Transform-based parameter dynamics, set:
 python train.py --config-name apps/colmap_3dgut.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_3dgut dataset.downsample_factor=2 model.use_unscented_transform=true
 ```
 
+To speed up the forward/backward pass with automatic mixed precision, set:
+```bash
+python train.py --config-name apps/colmap_3dgrt.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_fp16 enable_amp=true
+```
+
+### Hyperparameter search with Ray Tune
+
+We provide a small utility script leveraging [Ray Tune](https://docs.ray.io/en/latest/tune/index.html) to
+automatically explore the learning rate schedule using Population Based Training (PBT).
+
+```bash
+python ray_tune_train.py
+```
+
+The script spawns multiple trials in parallel, performs early stopping and
+dynamically perturbs the optimizer learning rates to seek improved
+performance over the defaults.
+
 
 If you use MCMC and Selective Adam in your research, please cite [3dgs-mcmc](https://github.com/ubc-vision/3dgs-mcmc), [taming-3dgs](https://github.com/humansensinglab/taming-3dgs),
 and [gSplat](https://github.com/nerfstudio-project/gsplat/tree/main) library from which the code was adopted (links to the code are provided in the source files).

--- a/configs/base_gs.yaml
+++ b/configs/base_gs.yaml
@@ -23,6 +23,8 @@ compute_extra_metrics: true
 
 enable_frame_timings: false
 
+enable_amp: false
+
 enable_writer: true
 writer:
   hit_stat_frequency: 999999

--- a/ray_tune_train.py
+++ b/ray_tune_train.py
@@ -1,0 +1,68 @@
+from typing import Dict, Any
+
+import hydra
+from ray import tune
+from ray.tune import CLIReporter
+from ray.tune.schedulers import ASHAScheduler, PopulationBasedTraining
+
+import torch
+from threedgrut.trainer import Trainer3DGRUT
+from ray.air import session
+
+
+def tune_train(config: Dict[str, Any]):
+    """Wrapper to launch training inside Ray Tune."""
+    overrides = []
+    for key, value in config.items():
+        if key in {"training_iteration", "reporter"}:
+            continue
+        overrides.append(f"{key}={value}")
+
+    with hydra.initialize_config_dir("configs"):
+        cfg = hydra.compose(config_name="apps/colmap_3dgrt.yaml", overrides=overrides)
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    def report(metrics):
+        session.report(metrics)
+
+    trainer = Trainer3DGRUT(cfg, device=device, report_hook=report)
+    trainer.run_training()
+
+
+def main():
+    scheduler = ASHAScheduler(metric="psnr", mode="max")
+    pbt = PopulationBasedTraining(
+        time_attr="training_iteration",
+        metric="psnr",
+        mode="max",
+        perturbation_interval=5,
+        hyperparam_mutations={
+            "optimizer.params.positions.lr": tune.loguniform(1e-5, 5e-4),
+            "optimizer.params.density.lr": tune.loguniform(1e-3, 0.1),
+        },
+    )
+
+    reporter = CLIReporter(metric_columns=["psnr"])
+
+    search_space = {
+        "path": "/data14/yunlong.li.2507/mipnerf360_dataset/bonsai",
+        "out_dir": "runs",
+        "experiment_name": "bonsai_3dgrt_tune",
+        "dataset.downsample_factor": 2,
+        "optimizer.type": "sghmc",
+        "optimizer.params.positions.lr": tune.loguniform(1e-5, 5e-4),
+        "optimizer.params.density.lr": tune.loguniform(1e-3, 0.1),
+    }
+
+    tuner = tune.Tuner(
+        tune.with_parameters(tune_train),
+        param_space=search_space,
+        tune_config=tune.TuneConfig(num_samples=4, scheduler=pbt),
+        run_config=tune.RunConfig(progress_reporter=reporter),
+    )
+    tuner.fit()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ git+https://github.com/rahul-goel/fused-ssim@1272e21a282342e89537159e4bad508b19b
 tqdm
 libigl
 pygltflib
+# Ray Tune support
+ray[tune]
 # --find-links https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.2_cu118.html
 # kaolin==0.17.0
 usd-core

--- a/train.py
+++ b/train.py
@@ -42,7 +42,7 @@ def _run(rank: int, world_size: int, conf: DictConfig) -> None:
         dist.init_process_group("nccl", rank=rank, world_size=world_size)
     torch.cuda.set_device(rank)
     from threedgrut.trainer import Trainer3DGRUT
-    trainer = Trainer3DGRUT(conf, device=torch.device(f"cuda:{rank}"))
+    trainer = Trainer3DGRUT(conf, device=torch.device(f"cuda:{rank}"), report_hook=None)
     trainer.run_training()
     if world_size > 1:
         dist.destroy_process_group()


### PR DESCRIPTION
## Summary
- add `ray_tune_train.py` script demonstrating Ray Tune with PBT
- expose optional `report_hook` in `Trainer3DGRUT`
- allow `train.py` to construct trainer with the new hook parameter
- note Ray Tune requirements and new example in README
- include `ray[tune]` in dependencies
- add AMP option for faster training

## Testing
- `python -m py_compile ray_tune_train.py train.py threedgrut/trainer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807d535428832ebfb19babc582eb0f